### PR TITLE
Speed up using cache

### DIFF
--- a/src/fpvgcc/datastructures/ntree.py
+++ b/src/fpvgcc/datastructures/ntree.py
@@ -19,6 +19,7 @@
 
 
 import logging
+from functools import cached_property, cache
 from os.path import commonprefix
 
 
@@ -36,7 +37,7 @@ class NTreeNode(object):
         self.node_t = node_t
         self.children = []
 
-    @property
+    @cached_property
     def tree(self):
         if isinstance(self.parent, NTree):
             return self.parent
@@ -167,11 +168,15 @@ class NTreeNode(object):
                     return res
         return ValueError
 
+    @cache
     def all_nodes(self):
-        yield self
-        for child in self.children:
-            for node in child.all_nodes():
-                yield node
+        def iter_all():
+            yield self
+            for child in self.children:
+                for node in child.all_nodes():
+                    yield node
+
+        return list(iter_all())
 
     @property
     def get_top_level_ancestor(self):

--- a/src/fpvgcc/gccMemoryMap.py
+++ b/src/fpvgcc/gccMemoryMap.py
@@ -19,6 +19,7 @@
 
 
 import logging
+from functools import cached_property
 
 from fpvgcc.datastructures.ntreeSize import SizeNTree, SizeNTreeNode
 
@@ -78,7 +79,7 @@ class GCCMemoryMapNode(SizeNTreeNode):
         self._fillsize = None
         self.fillsize = fillsize
 
-    @property
+    @cached_property
     def ctx(self):
         return self.parent.ctx
 
@@ -204,7 +205,7 @@ class GCCMemoryMapNode(SizeNTreeNode):
     def leafsize(self, value):
         raise AttributeError
 
-    @property
+    @cached_property
     def region(self):
         ctx = self.ctx
         if not isinstance(self.parent, GCCMemoryMap) and \

--- a/src/fpvgcc/gccMemoryMap.py
+++ b/src/fpvgcc/gccMemoryMap.py
@@ -206,12 +206,13 @@ class GCCMemoryMapNode(SizeNTreeNode):
 
     @property
     def region(self):
+        ctx = self.ctx
         if not isinstance(self.parent, GCCMemoryMap) and \
                 self.parent.region == 'DISCARDED':
             return 'DISCARDED'
         # Suppressed root identifiers for MSP430 GCC. A better mechanism to
         # provide user access to manipulate this set is needed.
-        if self.ctx and self.name in self.ctx.suppressed_names:
+        if ctx and self.name in ctx.suppressed_names:
             return 'DISCARDED'
         if self._address is None:
             return 'UNDEF'
@@ -219,7 +220,7 @@ class GCCMemoryMapNode(SizeNTreeNode):
             return "DISCARDED"
         for region in self.tree.memory_regions:
             if self._address in region:
-                if region.name in self.ctx.suppressed_regions:
+                if region.name in ctx.suppressed_regions:
                     return 'DISCARDED'
                 return region.name
         raise ValueError(self._address)
@@ -257,14 +258,15 @@ class GCCMemoryMap(SizeNTree):
             self._vector_regions = []
             ur.append('VEC')
         for node in self.root.all_nodes():
-            if node.region not in ur:
+            region = node.region
+            if region not in ur:
                 if self.collapse_vectors:
-                    if 'VEC' not in node.region:
-                        ur.append(node.region)
-                    elif node.region not in self._vector_regions:
-                        self._vector_regions.append(node.region)
+                    if 'VEC' not in region:
+                        ur.append(region)
+                    elif region not in self._vector_regions:
+                        self._vector_regions.append(region)
                 else:
-                    ur.append(node.region)
+                    ur.append(region)
         ur.remove('UNDEF')
         ur.remove('DISCARDED')
         return ur
@@ -273,11 +275,12 @@ class GCCMemoryMap(SizeNTree):
     def used_objfiles(self):
         of = []
         for node in self.root.all_nodes():
+            region = node.region
             if node.objfile is None and node.leafsize \
-                    and node.region not in ['DISCARDED', 'UNDEF']:
+                    and region not in ['DISCARDED', 'UNDEF']:
                 logging.warning(
                     "Object unaccounted for : {0:<40} {1:<15} {2:>5}"
-                    "".format(node.gident, node.region, str(node.leafsize))
+                    "".format(node.gident, region, str(node.leafsize))
                 )
                 continue
             if node.objfile not in of:
@@ -297,11 +300,12 @@ class GCCMemoryMap(SizeNTree):
     def used_arfiles(self):
         af = []
         for node in self.root.all_nodes():
+            region = node.region
             if node.arfile is None and node.leafsize \
-                    and node.region not in ['DISCARDED', 'UNDEF']:
+                    and region not in ['DISCARDED', 'UNDEF']:
                 logging.warning(
                     "Object unaccounted for : {0:<40} {1:<15} {2:>5}"
-                    "".format(node.gident, node.region, str(node.leafsize))
+                    "".format(node.gident, region, str(node.leafsize))
                 )
                 continue
             if node.arfile not in af:
@@ -313,13 +317,14 @@ class GCCMemoryMap(SizeNTree):
         af = []
         of = []
         for node in self.root.all_nodes():
+            region = node.region
             if node.arfile is None and node.leafsize \
-                    and node.region not in ['DISCARDED', 'UNDEF']:
+                    and region not in ['DISCARDED', 'UNDEF']:
                 if node.objfile is None and node.leafsize \
-                        and node.region not in ['DISCARDED', 'UNDEF']:
+                        and region not in ['DISCARDED', 'UNDEF']:
                     logging.warning(
                         "Object unaccounted for : {0:<40} {1:<15} {2:>5}"
-                        "".format(node.gident, node.region, str(node.leafsize))
+                        "".format(node.gident, region, str(node.leafsize))
                     )
                     continue
                 else:


### PR DESCRIPTION
Thanks for this very useful software! Here I propose an improvement:

### Problem
Scanning all symbols in .map file with `--ssym` takes a long time.
For example: takes up to 6.5 minutes to scan Nordic nRF52840 firmware (zephyr_final.map)

### What I did
I've modified the code to:
 - Reuse property read results
    Some read of `@property` was called multiple times in the same namespace (I mean, in one method).
 - Enable LRU cache for recursive and/or heavy operations
    Super-heavy operation like `all_nodes()` in `NTreeNode` and `region` in `GCCMemoryMapNode` were now sped up by LRU cache.

### Result
Before:
```
$ time python -m cProfile -o profile -m fpvgcc --ssym all ${PATH_TO_ZEPHYR_FINAL_MAP} > out_original

real    6m38.448s
user    6m35.456s
sys     0m2.968s
```

After:
```
$ time python -m cProfile -o profile -m fpvgcc --ssym all ${PATH_TO_ZEPHYR_FINAL_MAP} > out_modified

real    0m13.785s
user    0m13.616s
sys     0m0.150s
```

The output is the same.
```
$ diff out_original out_modified
$ # no output
```


Note: Please create `src/fpvgcc/__main__.py` with the following content to enable `python -m` invocation and reproduce the above result.
```
from fpvgcc.cli import main
main()
```